### PR TITLE
SFC(haml,scssの機能確認)、weplacker用loadersの記述の間違いを修正

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,21 +1,30 @@
-<template>
-  
+<template lang="haml">
+  %div
+    %h1.title {{ message }}
+      %p.title__sample {{mini}}
+    %Home
 </template>
 
 <script>
+import Home from "./components/home/index";
 export default {
   data: function () {
     return {
-      message: "ワーキングホリデー相談掲示板"
+      message: "ワーキングホリデー相談掲示板",
+      mini: "サンプル",
     }
-  }
+  },
+  components: { Home }
+
 }
 </script>
 
-<style scoped>
-p {
+<style scoped lang="scss" scoped>
+.title {
   font-size: 2em;
   text-align: center;
-  
+  &__sample {
+    color: blue;
+  }
 }
 </style>

--- a/app/javascript/components/home/index.vue
+++ b/app/javascript/components/home/index.vue
@@ -1,15 +1,17 @@
 <template lang="haml">
   -# %article
   -# %h1.title {{ title }}
-</template>
-
-<template>
-  
+  %h1{id: "subid"} {{ sub }}
 </template>
 
 <script>
+
 export default {
-  
+  data: function () {
+    return {
+      sub: "ワーキング"
+    }
+  },
 }
 </script>
 

--- a/app/javascript/packs/home/index.js
+++ b/app/javascript/packs/home/index.js
@@ -3,6 +3,15 @@ import Vue from 'vue/dist/vue.esm';
 const home = new Vue({
   
   
+  el: '#subid',
+  data: () => {
+    return {
+      message: "Can you say?"
+    }
+  },
+  components: { App }
+
+  
   
 })
 

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -63,11 +63,11 @@ Vue.use(TurbolinksAdapter)
 document.addEventListener('turbolinks:load', () => {
   const app = new Vue({
     el: '#hello',
-    // data: () => {
-    //   return {
-    //     message: "Can you say hello?"
-    //   }
-    // },
+    data: () => {
+      return {
+        message: "Can you say hello?"
+      }
+    },
     components: { App }
   })
 })

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,12 +1,11 @@
--# %h1 %Home#index
--# %p Find me in app/views/home/index.html.erb
+%h1 %Home#index
+%p Find me in app/views/home/index.html.erb
 
--# %div{id: "hello"}
-  -# {{message}}
-  -# %app
+%div{id: "hello"}
+  {{message}}
+  %app
 
 = javascript_pack_tag 'main'
-
 = stylesheet_pack_tag 'main'
 -# = javascript_pack_tag 'home/index'
 -# = javascript_pack_tag 'home/index.js'

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -5,3 +5,6 @@ const vue = require('./loaders/vue')
 environment.plugins.prepend('VueLoaderPlugin', new VueLoaderPlugin())
 environment.loaders.prepend('vue', vue)
 module.exports = environment
+
+const haml = require('./loaders/haml')
+environment.loaders.prepend('haml', haml)

--- a/config/webpack/loaders/haml.js
+++ b/config/webpack/loaders/haml.js
@@ -1,0 +1,6 @@
+module.exports = {
+  test: /\.haml$/,
+  use: [{
+    loader: 'haml-plain-loader'
+  }]
+}

--- a/config/webpack/loaders/vue.js
+++ b/config/webpack/loaders/vue.js
@@ -1,26 +1,12 @@
 module.exports = {
-  module: {
-    rules: [
-      {
-        test: /\.vue(\.erb)?$/,
-        use: ["vue-loader"],
-      },
-      {
-        test: /\.vue$/, 
-        use: ["vue-loader"],
-      },
-      {
-      test: /\.vue$/,
-      loader: 'vue-loader',
-        options: {
-          loaders: {
-            scss: 'vue-style-loader!css-loader!sass-loader', // <style lang="scss">
-            sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax' // <style lang="sass">
-          }
-        }
-      }
-    ]
-  },
+  test: /\.vue$/, 
+  loader: 'vue-loader',
+  options: {
+    loaders: {
+      scss: 'vue-style-loader!css-loader!sass-loader', // <style lang="scss">
+      sass: 'vue-style-loader!css-loader!sass-loader?indentedSyntax' // <style lang="sass">
+    }
+  }
 }
 
 


### PR DESCRIPTION
# What
- webpackとrails6のwebpackerの書き方の違いによるエラーを修正
- javascript/components/内の.vueファイルの<template>,<style>をそれぞれ、
haml,scssで書けるように修正
- コンポーネントが孫まで使用できることを確認

# Why
確認のためサンプルの作成