### PR TITLE
ヘッダーコンポーネント、ナビゲーションコンポーネント作成(プルダウンやリンクは未実装)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
-@import "config/colors";
-@import "reset";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "config/colors";
+@import "reset";
+

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,5 @@
 class HomeController < ApplicationController
   def index
-    @title = "ワーキングホリデー留学相談サイト"
-    
+    # @title = "ワーキングホリデー留学相談サイト"
   end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -5,11 +5,15 @@
 
 <script>
 import Home from "./components/home/index";
+
 export default {
   components: { Home }
 }
 </script>
 
 <style scoped lang="scss" scoped>
-
+  *, *:before, *:after {
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box
+  }
 </style>

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -1,0 +1,59 @@
+<template lang="haml">
+  %div.header
+    %div.header-block
+      %v-fa.header-block__home{icon: "home"}
+      %h1.header-block__title {{ app_name }}
+      %p.header-block__subtitle {{app_subtitle}}
+    %Navbar
+</template>
+
+<script>
+import Navbar from "./navbar";
+export default {
+  data: function () {
+    return {
+      app_name: "ワーキングホリデー相談掲示板",
+      app_subtitle: "経験談、相談、計画、なんでも投稿！!",
+      name: 'Header'
+    }
+  },
+  components: { Navbar },
+}
+</script>
+
+<style scoped lang="scss" scoped>
+.header {
+  width: 100%;
+  height: auto;
+  background-color: rgb(53, 83, 167);
+  .header-block {
+    width: 80%;
+    margin: 0 auto;
+    height: 100%;
+    background-color: rgb(53, 83, 167);
+    color: white;
+    padding: 1rem 0;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-align-items: center; 
+    align-items: center; 
+    &__home {
+    font-size: 3rem;
+    }
+    &__title {
+      font-size: 2rem;
+      text-align: center;
+      padding-left: 1rem;
+      font-weight: bold;
+      font-family: ヒラギノ丸ゴ ProN;
+      letter-spacing: 0.2rem;
+    }
+    &__subtitle {
+      margin-left:auto;
+      font-size: 1.3rem;
+      color: rgb(228, 223, 195);
+      font-family: ヒラギノ丸ゴ ProN;
+    }
+  }
+}
+</style>

--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -1,0 +1,68 @@
+<template lang="haml">
+  %div.navbar
+    %div.navbar__block.clearfix
+      %h1.country-choose 仮)情報の欲しい国を選択してください。
+      %ul.icons
+        %li.icons__first
+          %v-fa{icon: "plane-departure"}
+        %li.icons__second
+          %v-fa{icon: "envelope-open-text"}
+        %li.icons__third
+          %v-fa{icon: "info-circle"}
+        %li.icons__fourth
+          %v-fa{icon: "user"}
+</template>
+
+<script>
+export default {
+  data: function () {
+    return {
+      name: 'Navbar',
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss" scoped>
+.navbar {
+  width: 100%;
+  height: auto;
+  background-color: #fff;
+  box-shadow: rgb(53, 83, 167) 0px 2px 4px;
+  &__block{
+    width: 80%;
+    margin: 0 auto;
+    display: -webkit-flex;
+    display: flex;
+    -webkit-align-items: center; 
+    align-items: center; 
+    font-size: 1.2rem;
+    letter-spacing: 0.3rem;
+    &::after {
+      content: "";
+      display: block;
+      clear: both;
+    }
+    .country-choose{
+      float: left;
+      width: 60%;
+      font-weight: bold;
+      color: rgb(126, 18, 18); 
+    }
+    .icons{
+      text-align: right;
+      float: right;
+      width: 40%;
+      color: rgb(170, 158, 47);
+      height: 100%;
+      padding: 0.3rem 0;
+      display:table; 
+      table-layout: fixed;
+      ul.icons, li{
+        font-size: 2rem;
+        display:table-cell; 
+      }
+    }
+  }
+}
+</style>

--- a/app/javascript/components/home/index.vue
+++ b/app/javascript/components/home/index.vue
@@ -1,29 +1,29 @@
 <template lang="haml">
-  %div
-    %h1.title {{ app_name }}
-      %p.title__sub {{app_subtitle}}
+  %div.home
+    %Header
+    -# %Footer
 </template>
 
 <script>
-
+import Header from "../header";
+// import Footer from "../footer";
 export default {
   data: function () {
     return {
-      app_name: "ワーキングホリデー相談掲示板",
-      app_subtitle: "経験談、相談、計画、なんでも投稿可能！",
-      // name: 'Home'
+      name: 'Home'
     }
   },
+  components: { Header },
+  // components: { Footer },
 }
+
 </script>
 
 <style scoped lang="scss" scoped>
-.title {
-  font-size: 2rem;
-  text-align: center;
-  &__sub {
-    font-size: 1rem;
-    color: blue;
-  }
+.home {
+  width: 100%;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
 }
 </style>

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -58,6 +58,16 @@ import Vue from 'vue/dist/vue.esm'
 // import Vuex from 'vuex'
 import App from '../app.vue'
 
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faHome, faPlaneDeparture, faEnvelopeOpenText, faUser, faSearch, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
+import { faEye } from '@fortawesome/free-regular-svg-icons'
+// config.showMissingIcons = false;
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+
+library.add(faHome, faPlaneDeparture, faEnvelopeOpenText, faUser, faSearch, faInfoCircle, faEye)
+
+Vue.component('v-fa', FontAwesomeIcon);
+
 Vue.use(TurbolinksAdapter)
 
 document.addEventListener('turbolinks:load', () => {

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,5 +1,4 @@
 %div{id: "hello"}
   %app
-
 = javascript_pack_tag 'main'
 = stylesheet_pack_tag 'main'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "dependencies": {
     "@babel/core": "^7.0.0-0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.28",
+    "@fortawesome/free-regular-svg-icons": "^5.13.0",
+    "@fortawesome/free-solid-svg-icons": "^5.13.0",
+    "@fortawesome/vue-fontawesome": "^0.1.9",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",


### PR DESCRIPTION
# What
## 行なったこと
- Vueヘッダーコンポーネント作成
- Vueヘッダーコンポーネントの中にナビゲーションコンポーネント作成
- font-awesomeをRails6, Vue.jsの環境下で使用できるように、yarnの追加
yarn add @fortawesome/fontawesome-svg-core(SVGコア版のパッケージ)
yarn add @fortawesome/vue-fontawesome
yarn add @fortawesome/free-solid-svg-icons(中が塗りつぶされているアイコン,Solidスタイルにはfasというクラスを指定する)
yarn add @fortawesome/free-regular-svg-icons(線画で表現されたアイコン,Regularスタイルにはfarというクラスを指定する)
- font-awesomeを使用できるようにmain.jsの編集

# Why
- gemのfont awesomeが使用できないことに気づいたため、yarnでパッケージを導入する。
rails6では、webpackerを使ってコンパイルする。
yarnを使ってfontawesomeをインストールします。
yarnからインストールしたcss jsをwebpackerを使ってコンパイルし、fontawesomeを使用可能にする。