### PR TITLE
Vue Routerの修正

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,24 +1,24 @@
 <template lang="haml">
-  -# %div{id: "app"}
-  -#   %router-link{to: "{ name: 'home'}"}
-  -#   %router.push({ name: 'home'})
+  %router-view
+    %router-link{to: "{ name: 'home'}"}
+    -# %router.push({ name: 'home'})
 
-  %Home
 </template>
 
 <script>
 // import Vue from 'vue/dist/vue.esm'
+// import router from './router/router'
 import Home from "./components/home/index";
-
 export default {
   components: { Home },
-  
 }
 
-// var app = new Vue({
-//   router: router
-// }).$mount('#app')
-
+// document.addEventListener('DOMContentLoaded', () => {
+  // new Vue({
+  //   router: router
+  // }).$mount('#app')
+  // console.log("aaaaaaa")
+// });
 
 </script>
 

--- a/app/javascript/components/Footer.vue
+++ b/app/javascript/components/Footer.vue
@@ -1,0 +1,19 @@
+<template lang="haml">
+  %div.footer
+</template>
+
+<script>
+export default {
+  data: function () {
+    return {
+     
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss" scoped>
+.footer {
+ 
+}
+</style>

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -8,15 +8,13 @@
 </template>
 
 <script>
-// import Navbar from "./navbar";
-
 import Navbar from "./Navbar.vue";
 export default {
   data: function () {
     return {
       app_name: "ワーキングホリデー相談掲示板",
       app_subtitle: "経験談、相談、計画、なんでも投稿！!",
-      // name: 'Header'
+      name: 'header-component'
     }
   },
   components: { Navbar },

--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -15,11 +15,11 @@
 
 <script>
 export default {
-  // data: function () {
-  //   return {
-  //     name: 'Navbar',
-  //   }
-  // },
+  data: function () {
+    return {
+      name: 'navigation-component',
+    }
+  },
 }
 </script>
 

--- a/app/javascript/components/home/index.vue
+++ b/app/javascript/components/home/index.vue
@@ -1,25 +1,20 @@
 <template lang="haml">
   %div.home
     %Header
-   
-
-    -# %Footer
+    %Footer
 </template>
 
 <script>
-// import Header from "../header";
-// import Footer from "../footer";
-
 import Header from "../Header.vue";
-// import Footer from "../Footer.vue";
+import Footer from "../Footer.vue";
 
 export default {
-  // data: function () {
-  //   return {
-  //     name: 'Home'
-  //   }
-  // },
-  components: { Header,},
+  data: function () {
+    return {
+      name: 'main-page'
+    }
+  },
+  components: { Header, Footer},
 }
 
 </script>

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -53,11 +53,15 @@
 //
 // Then uncomment the code block below:
 //
+
 import TurbolinksAdapter from 'vue-turbolinks'
+
 import Vue from 'vue/dist/vue.esm'
-// import Vuex from 'vuex'
 import App from '../app.vue'
-// import Router from "../router/router.js";
+// import Vuex from 'vuex'
+
+import router from "../router/router.js"
+import VueRouter from 'vue-router'
 
 
 import { library } from '@fortawesome/fontawesome-svg-core'
@@ -69,22 +73,16 @@ library.add(faHome, faPlaneDeparture, faEnvelopeOpenText, faUser, faSearch, faIn
 
 Vue.component('v-fa', FontAwesomeIcon);
 
-Vue.use(TurbolinksAdapter)
+Vue.use(TurbolinksAdapter);
+Vue.use(VueRouter);
 
 document.addEventListener('turbolinks:load', () => {
-  const el = document.body.appendChild(document.createElement('hello'))
-  const app = new Vue({
-    el,
-    // Router,
-    render: h => h(App),
-    components: { App },
-    
-  })
+// document.addEventListener('DOMContentLoaded', () => {
+  new Vue({
+    el: '#app',
+    router,
+    render: (h) => h(App),
+    components: { App }
+  });
+});
 
-  // console.log(app)
-  // const app = new Vue({
-  // el: '#hello',
-  // components: { App },
-  // Router
-  // })
-})

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -1,18 +1,21 @@
-import Vue from 'vue/dist/vue.esm'
+import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Home from "../components/home/index"
 
 Vue.use(VueRouter)
-export default router
 
-var router = new VueRouter({
+
+const router = new VueRouter({
+  mode: 'history',
   routes: [
     {
       path: '/',
-      component: { Home },
+      component: Home,
       name: 'home',
     },
   ]
 })
+
+export default router
 
 

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,4 +1,3 @@
-%div{id: "hello"}
-  %app
 = javascript_pack_tag 'main'
 = stylesheet_pack_tag 'main'
+%div{id: "app"}


### PR DESCRIPTION
# What
- トップページ遷移をimportでなく、routerで行う
- 以前作成していたものは機能していないので修正をする

# Why
## 主に修正したところ
- html.hamlファイルにルーターのid(#app)を作成
- main.jsにルーターのインスタンスをrootのVueインスタンスに渡す(#appへ)
- app.vueからトップページへ
%router-viewこの記述が以前はなく動かなかった
%router-link{to: "{ name: 'home'}"}ルートが増えた時のためのページ指定のため。

- router.js
export default routerを一番下へ
mode: 'history',をたす、URL が見えるようになる 