### PR TITLE
vue routerからのページ遷移設定作成中一時コミット、共通部分、routerコンポーネント表示部分をapp.vueに設定

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,7 @@
 class HomeController < ApplicationController
   def index
   end
+  
+  def siteguide
+  end
 end

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,16 +1,31 @@
 <template lang="haml">
-  %router-view
-    -# %router-link{to: "{ name: 'home'}"}
-    %router.push({ name: 'home'})
+-# %div 
+-#   %router-view 
+-#     %router-link{to: "{ name: 'home'}"} ホーム
+  -# %router-link{":to" => "{ name: 'signup'}"}
+
+%div
+  %Header
+
+  -# %router-link{to: "{ name: 'home'}"} ホーム
+  -# %router-link{to: "{ name: 'signup'}"} ここ
+  -# %router-link{to: "{ name: 'home'}"}
+  %router-view 
+  %Footer
+
 
 </template>
 
 <script>
+import Header from "./components/Header.vue";
+import Footer from "./components/Footer.vue";
+
 // import Vue from 'vue/dist/vue.esm'
 // import router from './router/router'
-import Home from "./components/home/index";
+
+// import Home from "./components/home/index";
 export default {
-  components: { Home },
+  components: { Header, Footer },
 }
 
 // document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/components/Header.vue
+++ b/app/javascript/components/Header.vue
@@ -1,6 +1,7 @@
 <template lang="haml">
   %div.header
     %div.header__block
+      -# %router-link{to: "{ name: 'home'}"}
       %v-fa.header__block--iconhome{icon: "home"}
       %h1.header__block--title {{ app_name }}
       %p.header__block--subtitle {{app_subtitle}}

--- a/app/javascript/components/Navbar.vue
+++ b/app/javascript/components/Navbar.vue
@@ -8,7 +8,10 @@
         %li.icons__second
           %v-fa{icon: "envelope-open-text"}
         %li.icons__third
-          %v-fa{icon: "info-circle"}
+          -# %router-view 
+          %router-link{to: "{ name: 'siteguide'}"}
+            %v-fa{icon: "info-circle"}
+          
         %li.icons__fourth
           %UserPullDownMenu
 

--- a/app/javascript/components/UserPullDownMenu.vue
+++ b/app/javascript/components/UserPullDownMenu.vue
@@ -13,7 +13,15 @@ export default {
         '過去投稿記事',
         '新規登録',
         'ログイン',
-      ]
+      ],
+      // items: [
+      //   { label: 'プロフィール編集', url: '' },
+      //   { label: 'ログアウト', url: '' },
+      //   { label: '経験談投稿', url: '' },
+      //   { label: '過去投稿記事', url: '' },
+      //   { label: '新規登録', url: '' },
+      //   { label: 'ログイン', url: '' },
+      // ],
     }
   },
 
@@ -34,15 +42,44 @@ export default {
           <li class="menu">{{name}}
           </li>
           
-          <li v-for="item in items" :key="item">
+
+          <li 
+            v-for="item in items" 
+            :key="item"
+          >
             <a href="#" class="menu-item">{{item}}</a>
+
+          
+
+            
+
           </li>
         </ul>
       </transition>
     </div>
   `,
 
+  // <router-link :to="#" class="menu-item">{{item}}</router-link>
+  
+  // <li 
+  //   v-for="item in items" 
+  //   :key="item"
+  //   @click="getCreateUrl(item.url)"
+  // >
+  // <li
+  //   v-for="item in items"
+  //   v-bind:key="item.item_id"
+  //   <a href="javascript:void(0)" @click.prevent="onClick(item.path)">
+  //     {{item}}
+  //   </a>
+  // >  
+
   methods: {
+
+    // getCreateUrl(url) {
+    //   location.href=`${url}`
+    // },
+
     beforeEnter: function (el) {
       el.style.height = '0px'
       el.style.opacity = '0'

--- a/app/javascript/components/home/SiteGuide.vue
+++ b/app/javascript/components/home/SiteGuide.vue
@@ -1,0 +1,26 @@
+<template lang="haml">
+  %div.guide
+    %div ページ紹介
+      %h1 {{name}}
+    -# %router-view
+</template>
+
+<script>
+export default {
+  data: function () {
+    return {
+      name: "サイト案内"
+    }
+  },
+}
+</script>
+
+<style scoped lang="scss" scoped>
+  .guide {
+  width: 100%;
+  height: 100vh;
+  // height: 100%;
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/app/javascript/components/home/index.vue
+++ b/app/javascript/components/home/index.vue
@@ -1,19 +1,26 @@
 <template lang="haml">
   %div.home
-    %Header
-    %Footer
+    -#   %Header
+    -#   %router-link{to: "{ name: 'home'}"} 
+    -#   %Footer
+    %p トップページのビュー(ここに中身のコンポーネントを作成して入れる)
+   
+    -# <p>{{msg}}<button @click="say">click</button></p>
+    -# %router-view 
 </template>
 
 <script>
-import Header from "../Header.vue";
-import Footer from "../Footer.vue";
+// import Header from "../Header.vue";
+// import Footer from "../Footer.vue";
 
 export default {
   data: function () {
     return {
+    
     }
   },
-  components: { Header, Footer},
+  // components: { Header, Footer},
+  
 }
 
 </script>
@@ -22,6 +29,7 @@ export default {
 .home {
   width: 100%;
   height: 100vh;
+  // height: 100%;
   margin: 0;
   padding: 0;
 }

--- a/app/javascript/packs/main.js
+++ b/app/javascript/packs/main.js
@@ -8,6 +8,9 @@ import router from "../router/router.js"
 import VueRouter from 'vue-router'
 import anime from 'animejs/lib/anime.es.js';
 import moment from "moment";
+// import axios from 'axios'
+// axios.defaults.baseURL = process.env.BASE_URL;
+// export default axios;
 
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faHome, faPlaneDeparture, faEnvelopeOpenText, faUser, faSearch, faInfoCircle } from '@fortawesome/free-solid-svg-icons'
@@ -20,6 +23,7 @@ Vue.component('v-fa', FontAwesomeIcon);
 
 Vue.use(TurbolinksAdapter);
 Vue.use(VueRouter);
+// Vue.use(axios);
 
 document.addEventListener('turbolinks:load', () => {
 // document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/router/router.js
+++ b/app/javascript/router/router.js
@@ -1,9 +1,16 @@
-import Vue from 'vue'
+// import Vue from 'vue'
+import Vue from 'vue/dist/vue.esm'
 import VueRouter from 'vue-router'
 import Home from "../components/home/index"
+import SiteGuide from "../components/home/SiteGuide"
+import SignUp from "../components/user/SignUp"
+import SignIn from "../components/user/SignIn"
+import SignOut from "../components/user/SignOut"
+
 
 Vue.use(VueRouter)
 
+// { path: 'アクセスされるURL', component: '使用するコンポーネント', name: 'pathの名前'}
 
 const router = new VueRouter({
   mode: 'history',
@@ -13,22 +20,26 @@ const router = new VueRouter({
       component: Home,
       name: 'home',
     },
-    // {
-    //   path: '/user/SignUp',
-    //   component: SignUp,
-    //   name: 'signup',
-    // },
-    // {
-    //   path: '/user/SignIn',
-    //   component: SignIn,
-    //   name: 'signin',
-    // },
-    // {
-    //   path: '/user/SignOut',
-    //   component: SignOut,
-    //   name: 'signout',
-    // },
-
+    {
+      path: '/home/siteguide',
+      component: SiteGuide,
+      name: 'siteguide',
+    },
+    {
+      path: '/users/sign_up',
+      component: SignUp,
+      name: 'signup',
+    },
+    {
+      path: '/users/sign_in',
+      component: SignIn,
+      name: 'signin',
+    },
+    {
+      path: '/users/sign_out',
+      component: SignOut,
+      name: 'signout',
+    },
   ]
 })
 

--- a/app/views/home/index.html.haml
+++ b/app/views/home/index.html.haml
@@ -1,3 +1,0 @@
--# = javascript_pack_tag 'main'
--# = stylesheet_pack_tag 'main'
--# %div{id: "app"}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,4 +12,4 @@
     = yield
     = javascript_pack_tag 'main', 'data-turbolinks-track': 'reload'
     = stylesheet_pack_tag 'main', media: 'all', 'data-turbolinks-track': 'reload'
-    %div{id: "app"}
+    %div#app

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,23 @@ Rails.application.routes.draw do
     registrations: 'registrations'
   }
 
+ 
+
   root to: 'home#index'
+  # resources :home, only: [:index] do
+  #   collection do
+  #     get :siteguide
+  #   end
+  # end
+
+
+  get 'home#siteguide', to: 'home#index' 
+  # 全てpages/indexを見にいくように設定する
+  # get 'pages/page1', to: 'pages#index' 
+  # get 'pages/page2', to: 'pages#index'
+
   resources :users
   resources :articles
 
 end
+


### PR DESCRIPTION
# What
## ページ内変更点
- components/home/indexでimportしていたheader,footerを全ページに表示させるため、共通部分のコンポーネントapp.vueへ移動する。

## 今後の修正箇所
- routerにはnameで指定したパスへ遷移できるよう設定しているが、Navbarからsiteguideコンポーネントに移動する際、ルーティングエラーが起こるため、修正必要あり。
- v-forで配列dataへのそれぞれのパスを設定する方法を現在学習中。

### 現在までの作業を一時コミットする