### PR TITLE
Error: Avoided redundant navigation to current locationエラー

### DIFF
--- a/app/javascript/components/UserPullDownMenu.vue
+++ b/app/javascript/components/UserPullDownMenu.vue
@@ -21,6 +21,7 @@
         @click="getCreateUrl(item.path)"
         >  
         <router-link :to="{label: item.path}" class="menu-item">{{item.label}}</router-link>
+        <!-- <router-link :to="{ label: item.path, query: { url: thread.url, title: thread.title }}"> -->
         
       </li>
     </ul>
@@ -49,7 +50,12 @@ export default {
 
   methods: {
     getCreateUrl(path) {
-      this.$router.push(path)
+      if (this.$router.path !== { path: this.currentRoutePath }) {
+        this.$router.push(path)
+      }
+
+      // this.$router.push(path)
+
       // location.href=`${path}`
     },
     


### PR DESCRIPTION
- vueルーターを使用して、既にいる同じページにリダイレクトしようとすると発生するエラー
- router-linkリダイレクトする前に現在のリンク以外の時を指定。
- 現在も同じエラー状態